### PR TITLE
WF-65756-Add hyperlink to Markdown to Word table

### DIFF
--- a/java-file-formats/word-library/convert-markdown-to-word-document-in-java.md
+++ b/java-file-formats/word-library/convert-markdown-to-word-document-in-java.md
@@ -348,7 +348,7 @@ N> Hook the event handler before opening a Word document as per the above code e
 </td>
 <td style="width: 41.7072%;">
 <p>For image, enclose an alternative text within the brackets [], and then link of the image source within parentheses ().</p>
-<p>If URL path is base64string, then it will be preserved properly in Word document. Otherwise, you can also {{'[set image from stream while opening Markdown file.](https://help.syncfusion.com/file-formats/docio/convert-markdown-to-word-document-in-csharp#customize-image-data)'| markdownify }}</p>
+<p>If URL path is base64string, then it will be preserved properly in Word document. Otherwise, you can also {{'[set image from stream while opening Markdown file.](https://help.syncfusion.com/java-file-formats/word-library/convert-markdown-to-word-document-in-csharp#customize-image-data)'| markdownify }}</p>
 </td>
 </tr>
 <tr>

--- a/java-file-formats/word-library/convert-markdown-to-word-document-in-java.md
+++ b/java-file-formats/word-library/convert-markdown-to-word-document-in-java.md
@@ -348,7 +348,7 @@ N> Hook the event handler before opening a Word document as per the above code e
 </td>
 <td style="width: 41.7072%;">
 <p>For image, enclose an alternative text within the brackets [], and then link of the image source within parentheses ().</p>
-<p>If URL path is base64string, then it will be preserved properly in Word document. Otherwise, you can also {{'[set image from stream while opening Markdown file.](https://help.syncfusion.com/java-file-formats/word-library/convert-markdown-to-word-document-in-csharp#customize-image-data)'| markdownify }}</p>
+<p>If URL path is base64string, then it will be preserved properly in Word document. Otherwise, you can also {{'[set image from stream while opening Markdown file.](https://help.syncfusion.com/java-file-formats/word-library/convert-markdown-to-word-document-in-java#customize-image-data)'| markdownify }}</p>
 </td>
 </tr>
 <tr>

--- a/java-file-formats/word-library/convert-markdown-to-word-document-in-java.md
+++ b/java-file-formats/word-library/convert-markdown-to-word-document-in-java.md
@@ -348,7 +348,7 @@ N> Hook the event handler before opening a Word document as per the above code e
 </td>
 <td style="width: 41.7072%;">
 <p>For image, enclose an alternative text within the brackets [], and then link of the image source within parentheses ().</p>
-<p>If URL path is base64string, then it will be preserved properly in Word document. Otherwise, you can also set image from stream while opening Markdown file.</p>
+<p>If URL path is base64string, then it will be preserved properly in Word document. Otherwise, you can also {{'[set image from stream while opening Markdown file.](https://help.syncfusion.com/file-formats/docio/convert-markdown-to-word-document-in-csharp#customize-image-data)'| markdownify }}</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
<table>
<tr>
<td>
Task Link
</td>
<td>
<a href="https://syncfusion.atlassian.net/browse/WF-65756">https://syncfusion.atlassian.net/browse/WF-65756</a>
</td>
</tr>
<tr>
<td>
Description
</td>
<td>
Add hyperlinks for new features in DocIO
</td>
</tr>
<td>
Content review confirmation
</td>
<td>
 Done
</td>
</tr>
</table>