### PR TITLE
Reverting Trademark Symbol in unwanted places

### DIFF
--- a/java-file-formats/Licensing/how-to-register-in-an-application.md
+++ b/java-file-formats/Licensing/how-to-register-in-an-application.md
@@ -32,7 +32,7 @@ Import ‘syncfusion.licensing' package and register the license key in the **ma
 import com.syncfusion.licensing.*;
 
 static void main() { 
-// Register Syncfusion<sup style="font-size:70%">&reg;</sup> license 
+// Register Syncfusion license 
 SyncfusionLicenseProvider.registerLicense("YOUR LICENSE KEY"); 
 }
 {% endhighlight %}


### PR DESCRIPTION
<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr;border-width:100%'>

<div style='direction:ltr;margin-top:0in;margin-left:0in;width:7.7416in'>

<div style='direction:ltr;margin-top:0in;margin-left:0in;width:7.7416in'>

<div style='direction:ltr'>


Title | Description
-- | --
Task Link | Revert   Syncfusion, Essential Studio trademark symbol in unwanted places
Feature description | Check   the occurrence of the trademark symbol and revert the changes in unwanted   places
Analysis and design | No   design changes required
Output screenshots | N/A
Areas affected and ensured | Changes   included in java-file-formats md files
Test cases |  
Testbed sample location | N/A
Additional Checklist | Did you run         the automation against your fix? No     Is there any API name change? N/A     Is there any existing behavior change of other features         due to this code change? No.     Does your new code introduce new warnings or binding         errors? No.     Does your code pass all FxCop and StyleCop rules? N/A.     Did you record this case in the unit test or UI test?         N/A



</div>

</div>

</div>

</div>

<!--EndFragment-->
</body>

</html>
