### PR TITLE
Documentation(1032578): Update code snippet tab name for Java Word Library

### DIFF
--- a/java-file-formats/Installation/configure-to-download-syncfusion-java-packages-from-gradle.md
+++ b/java-file-formats/Installation/configure-to-download-syncfusion-java-packages-from-gradle.md
@@ -1,37 +1,33 @@
 ---
-title: Download Syncfusion Java packages from Gradle | Syncfusion
-description: This section demonstrates how to configure and download required Jars from Gradle (Jar configuration)
+title: Configure Gradle for Syncfusion Java packages | Syncfusion
+description: Learn how to configure Gradle repositories and dependencies to download and use Syncfusion Java packages
 platform: java-file-formats
 control: general
 documentation: UG
 ---
-# Configure to download Syncfusion<sup style="font-size:70%">&reg;</sup> Java packages from Gradle
+# Configure Gradle for Syncfusion<sup style="font-size:70%">&reg;</sup> Java packages
 
 You can easily download the Syncfusion<sup style="font-size:70%">&reg;</sup> packages for Java using the [maven repository](https://jars.syncfusion.com/).
  
 The following command shows how to mention the repository in Gradle.
 
-<table>
-<tr>
-<td>
-repositories&nbsp;{<br />
-&nbsp;&nbsp;&nbsp;maven&nbsp; {<br />
-&nbsp;&nbsp;&nbsp;&nbsp;<span style="color:green;font-size:13px;font-style:italic">&nbsp;&nbsp;//Syncfusion<sup style="font-size:70%">&reg;</sup> maven repository to download the artifacts</span>.<br />
-&nbsp;&nbsp;&nbsp;&nbsp;url "https://jars.syncfusion.com/repository/maven-public/"<br />
-}<br />
+{% tabs %}
+{% highlight gradle tabtitle="Gradle" %}
+repositories {
+    maven {
+       //Syncfusion® maven repository to download the artifacts.
+       url "https://jars.syncfusion.com/repository/maven-public/"
+    }
 }
-</td>
-</tr>
-</table>
+{% endhighlight %}
+{% endtabs %}
 
 The following command shows how to refer to the Syncfusion<sup style="font-size:70%">&reg;</sup> package in Gradle, which needs to be used in your project as the dependency.
 
-<table>
-<tr>
-<td>
-	dependencies &nbsp;{<br />
- &nbsp;&nbsp;&nbsp;&nbsp;implementation 'com.syncfusion:syncfusion-docio:18.4.0.30'<br />
+{% tabs %}
+{% highlight gradle tabtitle="Gradle" %}
+dependencies {
+    implementation 'com.syncfusion:syncfusion-docio:18.4.0.30'
 }
-</td>
-</tr>
-</table>
+{% endhighlight %}
+{% endtabs %}

--- a/java-file-formats/Installation/configure-to-download-syncfusion-java-packages-from-gradle.md
+++ b/java-file-formats/Installation/configure-to-download-syncfusion-java-packages-from-gradle.md
@@ -5,14 +5,14 @@ platform: java-file-formats
 control: general
 documentation: UG
 ---
-# Configure Gradle for Syncfusion<sup style="font-size:70%">&reg;</sup> Java packages
+# Configure Gradle for Syncfusion<sup>&reg;</sup> Java packages
 
 You can easily download the Syncfusion<sup style="font-size:70%">&reg;</sup> packages for Java using the [maven repository](https://jars.syncfusion.com/).
  
 The following command shows how to mention the repository in Gradle.
 
 {% tabs %}
-{% highlight gradle tabtitle="Gradle" %}
+{% highlight groovy tabtitle="Gradle" %}
 repositories {
     maven {
        //Syncfusion® maven repository to download the artifacts.
@@ -25,7 +25,7 @@ repositories {
 The following command shows how to refer to the Syncfusion<sup style="font-size:70%">&reg;</sup> package in Gradle, which needs to be used in your project as the dependency.
 
 {% tabs %}
-{% highlight gradle tabtitle="Gradle" %}
+{% highlight groovy tabtitle="Gradle" %}
 dependencies {
     implementation 'com.syncfusion:syncfusion-docio:18.4.0.30'
 }

--- a/java-file-formats/word-library/Installation/configure-to-download-syncfusion-java-packages-from-gradle.md
+++ b/java-file-formats/word-library/Installation/configure-to-download-syncfusion-java-packages-from-gradle.md
@@ -11,27 +11,23 @@ You can easily download the Syncfusion<sup style="font-size:70%">&reg;</sup> pac
  
 The following command shows how to mention the repository in Gradle.
 
-<table>
-<tr>
-<td>
-repositories&nbsp;{<br />
-&nbsp;&nbsp;&nbsp;maven&nbsp; {<br />
-&nbsp;&nbsp;&nbsp;&nbsp;<span style="color:green;font-size:13px;font-style:italic">&nbsp;&nbsp;//Syncfusion<sup style="font-size:70%">&reg;</sup> maven repository to download the artifacts</span>.<br />
-&nbsp;&nbsp;&nbsp;&nbsp;url "https://jars.syncfusion.com/repository/maven-public/"<br />
-}<br />
+{% tabs %}
+{% highlight gradle tabtitle="Gradle" %}
+repositories {
+    maven {
+       //Syncfusion® maven repository to download the artifacts.
+       url "https://jars.syncfusion.com/repository/maven-public/"
+    }
 }
-</td>
-</tr>
-</table>
+{% endhighlight %}
+{% endtabs %}
 
 The following command shows how to refer to the Syncfusion<sup style="font-size:70%">&reg;</sup> package in Gradle, which needs to be used in your project as the dependency.
 
-<table>
-<tr>
-<td>
-	dependencies &nbsp;{<br />
- &nbsp;&nbsp;&nbsp;&nbsp;implementation 'com.syncfusion:syncfusion-docio:18.4.0.30'<br />
+{% tabs %}
+{% highlight gradle tabtitle="Gradle" %}
+dependencies {
+    implementation 'com.syncfusion:syncfusion-docio:18.4.0.30'
 }
-</td>
-</tr>
-</table>
+{% endhighlight %}
+{% endtabs %}

--- a/java-file-formats/word-library/Installation/configure-to-download-syncfusion-java-packages-from-gradle.md
+++ b/java-file-formats/word-library/Installation/configure-to-download-syncfusion-java-packages-from-gradle.md
@@ -5,14 +5,14 @@ platform: java-file-formats
 control: general
 documentation: UG
 ---
-# Configure Gradle to download Syncfusion<sup style="font-size:70%">&reg;</sup> Java packages
+# Configure Gradle to download Syncfusion<sup>&reg;</sup> Java packages
 
 You can easily download the Syncfusion<sup style="font-size:70%">&reg;</sup> packages for Java using the [maven repository](https://jars.syncfusion.com/).
  
 The following command shows how to mention the repository in Gradle.
 
 {% tabs %}
-{% highlight gradle tabtitle="Gradle" %}
+{% highlight groovy tabtitle="Gradle" %}
 repositories {
     maven {
        //Syncfusion® maven repository to download the artifacts.
@@ -25,7 +25,7 @@ repositories {
 The following command shows how to refer to the Syncfusion<sup style="font-size:70%">&reg;</sup> package in Gradle, which needs to be used in your project as the dependency.
 
 {% tabs %}
-{% highlight gradle tabtitle="Gradle" %}
+{% highlight groovy tabtitle="Gradle" %}
 dependencies {
     implementation 'com.syncfusion:syncfusion-docio:18.4.0.30'
 }

--- a/java-file-formats/word-library/Installation/configure-to-download-syncfusion-java-packages-from-gradle.md
+++ b/java-file-formats/word-library/Installation/configure-to-download-syncfusion-java-packages-from-gradle.md
@@ -5,7 +5,7 @@ platform: java-file-formats
 control: general
 documentation: UG
 ---
-# Configure to download Syncfusion<sup style="font-size:70%">&reg;</sup> Java packages from Gradle
+# Configure Gradle to download Syncfusion<sup style="font-size:70%">&reg;</sup> Java packages
 
 You can easily download the Syncfusion<sup style="font-size:70%">&reg;</sup> packages for Java using the [maven repository](https://jars.syncfusion.com/).
  

--- a/java-file-formats/word-library/jars-required.md
+++ b/java-file-formats/word-library/jars-required.md
@@ -10,9 +10,9 @@ documentation: UG
 
 The following jar files are required to be referenced in your Java application.
 
-1. syncfusion<sup style="font-size:70%">&reg;</sup>-docio
+1. syncfusion-docio
 
-2. syncfusion<sup style="font-size:70%">&reg;</sup>-javahelper
+2. syncfusion-javahelper
 
 Get the dependent jar files by installing [file formats controls](https://www.syncfusion.com/sales/products/fileformats?utm_source=ug&utm_medium=listing&utm_campaign=java-word-library#). You can find the required jars in the build installed drive.
 


### PR DESCRIPTION
In this PR, we have updated the code snippet tab name for Java Word Library UG pages.

https://dev.azure.com/EssentialStudio/Document%20Processing%20Libraries/_workitems/edit/1032578